### PR TITLE
Fix core and policy args count

### DIFF
--- a/lvmcache-statistics.sh
+++ b/lvmcache-statistics.sh
@@ -80,11 +80,11 @@ CoreArgs=""
 
 if [ ${NrCoreArgs} -ne 0 ]; then
 
-  for ITEM in $(seq $((INDEX+1)) $((2*NrCoreArgs+INDEX)) ); do
+  for ITEM in $(seq $((INDEX+1)) $((NrCoreArgs+INDEX)) ); do
      CoreArgs="${CoreArgs}${RESULTS[${ITEM}]} "
   done
 
-  INDEX=$((INDEX+2*NrCoreArgs))
+  INDEX=$((INDEX+NrCoreArgs))
 fi
 
 INDEX=$((INDEX+1))
@@ -95,11 +95,11 @@ PolicyArgs=""
 
 if [ ${NrPolicyArgs} -ne 0 ]; then
 
-  for ITEM in $(seq $((INDEX+1)) $((2*NrPolicyArgs+INDEX)) ); do
+  for ITEM in $(seq $((INDEX+1)) $((NrPolicyArgs+INDEX)) ); do
      PolicyArgs="${PolicyArgs}${RESULTS[${ITEM}]} "
   done
 
-  INDEX=$((INDEX+2*NrPolicyArgs))
+  INDEX=$((INDEX+NrPolicyArgs))
 fi
 
 ##################################################################


### PR DESCRIPTION
The core and policy args count includes both the keys and values already, so does not need to be multiplied * 2.

Ref: In https://www.kernel.org/doc/Documentation/device-mapper/cache.txt, core args and policy arg count are specifed as "must be even".